### PR TITLE
actions para testes e2e

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,0 +1,31 @@
+name: Run E2E Tests
+
+on: [pull_request]
+
+jobs:
+  run-e2e-tests:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: bitnami/postgresql
+        ports:
+          - 5432:5432
+        env:
+          POSTGRESQL_USERNAME: docker
+          POSTGRESQL_PASSWORD: docker
+          POSTGRESQL_DATABASE: apisolid
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          
+      - run: npm ci
+      - run: npm run test:e2e
+        env:
+          JWT_SECRET: testing
+          DATABASE_URL: "postgresql://docker:docker@localhost:5432/apisolid?schema=public"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the execution of end-to-end (E2E) tests for pull requests. The most important changes include setting up the workflow configuration, defining the job to run E2E tests, and specifying the necessary services and steps.

New GitHub Actions workflow:

* [`.github/workflows/run-e2e-tests.yml`](diffhunk://#diff-65f729bb8a45b44779a3c7ac8094e22dcaf9e90526583c06b9a27e64418a9a34R1-R31): Added a new workflow named "Run E2E Tests" that triggers on pull requests. The workflow includes a job that runs on `ubuntu-latest`, sets up a PostgreSQL service, and executes E2E tests using Node.js.